### PR TITLE
Early-finish nodes with different statuses

### DIFF
--- a/apps/pushy/include/pushy_sql.hrl
+++ b/apps/pushy/include/pushy_sql.hrl
@@ -14,7 +14,7 @@
                       quorum_failed |
                       aborted.
 
--type job_node_status() :: new | ready | running | complete | aborted | unavailable | nacked | faulty | was_ready.
+-type job_node_status() :: new | ready | running | complete | aborted | unavailable | nacked | crashed | was_ready.
 
 %% random PoC hard-codings
 -define(POC_ORG_ID, <<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">>).


### PR DESCRIPTION
depending on whether they were running or not,
so that users can get some idea of whether anything
was run on the node, or not
