### PR TITLE
Corrected formatting of jobs endpoint and added status

### DIFF
--- a/apps/pushy/priv/pgsql_statements.config
+++ b/apps/pushy/priv/pgsql_statements.config
@@ -33,7 +33,7 @@
    " WHERE jobs.id = $1">>}.
 
 {find_jobs_by_org,
- <<"SELECT id, created_at",
+ <<"SELECT id, created_at, status",
    " FROM jobs",
    " WHERE (org_id = $1)">>}.
 

--- a/apps/pushy/src/pushy_jobs_resource.erl
+++ b/apps/pushy/src/pushy_jobs_resource.erl
@@ -76,7 +76,7 @@ from_json(Req, State) ->
 to_json(Req, #config_state{organization_guid = OrgId} = State) ->
     {ok, Jobs} = pushy_sql:fetch_jobs(OrgId),
 
-    {jiffy:encode([{Jobs}]), Req, State}.
+    {jiffy:encode(Jobs), Req, State}.
 
 % Private stuff
 


### PR DESCRIPTION
Jobs were being returned as one big JSON object with duplicate keys. Fixed that and added the job status. This was cherry-picked from md/visualization
