### PR TITLE
Lookup OrgId from opscode-account

### DIFF
--- a/apps/pushy/src/pushy_org.erl
+++ b/apps/pushy/src/pushy_org.erl
@@ -8,7 +8,6 @@
 -module(pushy_org).
 
 -include_lib("eunit/include/eunit.hrl").
--include_lib("chef_req/include/chef_rest_client.hrl").
 
 -export([
           fetch_org_id/1,
@@ -22,11 +21,9 @@
 -spec fetch_org_id(OrgName :: string()) -> binary() | not_found.
 fetch_org_id(OrgName) ->
     {ok, Key} = chef_keyring:get_key(pivotal),
-    User = #chef_rest_client{user_name = "pivotal",
-                             private_key = Key,
-                             request_source = user},
-    Headers =  chef_rest_client:generate_signed_headers(User, <<"get">>,
-                                                        path(OrgName), <<"">>),
+    Headers =  chef_authn:sign_request(Key, <<"pivotal">>,
+                                       <<"get">>, now,
+                                       path(OrgName)),
     fetch_org_id(OrgName, Headers).
 
 fetch_org_id(OrgName, Headers) ->

--- a/rebar.config
+++ b/rebar.config
@@ -17,8 +17,6 @@
   {sqerl, ".*", {git, "git@github.com:opscode/sqerl.git", {branch, "master"}}},
   {chef_authn, ".*",
    {git, "git@github.com:opscode/chef_authn.git", {branch, "master"}}},
-  {chef_req, ".*",
-   {git, "git@github.com:opscode/chef_req.git", {branch, "jc/OC-4912/lookup-org_id"}}},
   {pushy_common, ".*",
    {git, "git@github.com:opscode/pushy_common.git", {branch, "master"}}},
   {ej, ".*", {git, "git@github.com:seth/ej.git", {branch, "master"}}},


### PR DESCRIPTION
- Remove stubbed out fetch_org_id
- use chef_rest_client to generate signed headers and connect to opscode-account
