### PR TITLE
Fully decoupled pushy_node_state FSM start from command switch

### DIFF
--- a/apps/pushy/src/pushy_command_switch.erl
+++ b/apps/pushy/src/pushy_command_switch.erl
@@ -15,7 +15,8 @@
 %% ------------------------------------------------------------------
 
 -export([start_link/1,
-         send_command/2]).
+         send_command/2,
+         send_command_after/3]).
 
 %% ------------------------------------------------------------------
 %% Private Exports - only exported for instrumentation
@@ -73,6 +74,10 @@ send_command(NodeRefs, Message) when is_list(NodeRefs)
     gen_server:call(?MODULE, {send_multi, hmac_sha256, NodeRefs, Message});
 send_command(NodeRefs, Message) when is_list(NodeRefs)  ->
     gen_server:call(?MODULE, {send_multi, rsa2048_sha1, NodeRefs, Message}).
+
+-spec send_command_after(node_ref(), ejson(), pos_integer()) -> pid().
+send_command_after(NodeRefs, Message, Interval) ->
+    erlang:spawn_link(fun() -> send_after(NodeRefs, Message, Interval) end).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
@@ -287,3 +292,7 @@ node_to_addr_lookup(Node, #state{node_to_addr = NodeMap}) ->
         error -> error;
         {ok, Value} -> Value
     end.
+
+send_after(NodeRefs, Message, Interval) ->
+    timer:sleep(Interval),
+    send_command(NodeRefs, Message).

--- a/apps/pushy/src/pushy_node_state.erl
+++ b/apps/pushy/src/pushy_node_state.erl
@@ -91,7 +91,8 @@ init([NodeRef]) ->
         %% assigned before anyone else tries to start things up gproc:reg can only return
         %% true or throw
         true = gproc:reg({n, l, GprocName}),
-        State1 = force_abort(State),
+        send_abort(NodeRef, 10),
+        State1 = arm_rehab_timer(State),
         pushy_node_status_updater:create(NodeRef, ?POC_ACTOR_ID, shutdown),
         {ok, state_transition(init, rehab, State1), State1}
     catch
@@ -209,10 +210,22 @@ send_info(NodeRef, Message) ->
     end.
 
 force_abort(#state{node_ref=NodeRef}=State) ->
-    Message = {[{type, abort}]},
-    ok = pushy_command_switch:send_command(NodeRef, Message),
+    ok = send_abort(NodeRef),
+    arm_rehab_timer(State).
+
+arm_rehab_timer(State) ->
     TRef = timer:send_after(rehab_interval(), rehab_again),
     State#state{state_timer=TRef}.
+
+send_abort(NodeRef) ->
+    send_abort(NodeRef, 0).
+
+send_abort(NodeRef, 0) ->
+    Message = {[{type, abort}]},
+    pushy_command_switch:send_command(NodeRef, Message);
+send_abort(NodeRef, Interval) ->
+    Message = {[{type, abort}]},
+    pushy_command_switch:send_command_after(NodeRef, Message, Interval).
 
 state_transition(Current, New, #state{node_ref=NodeRef, watchers=Watchers}) ->
     lager:debug("~p transitioning from ~p to ~p~n", [NodeRef, Current, New]),


### PR DESCRIPTION
A deadlock could occur when the command switch started a node state
FSM process in response to a pushy message. The deadlock happened
because the command switch would block waiting on the supervisor
to start the FSM process but the FSM process was sending command
messages via the command switch.

This commit adds a "send after" capability to the command switch
such that we can decouple the FSM from the switch at startup.
