### PR TITLE
Ma/oc 4290 abort msg deadlock

### DIFF
--- a/apps/pushy/src/pushy_node_state.erl
+++ b/apps/pushy/src/pushy_node_state.erl
@@ -129,11 +129,17 @@ init([NodeRef, NodeAddr]) ->
             {stop, state_transition(init, shutdown, State), State}
     end.
 
+%%
+%% Our usage pattern is to create the FSM and immediately send a message (most likely a
+%% heartbeat), so this timeout will often never fire because we get a message
+%% first. handle_info will get heartbeat messages and resend them, while any others should
+%% be ignored, as they aren't relevant in post_init.
+%% 
 post_init(timeout, State) ->
     State1 = force_abort(State),
     {next_state, state_transition(init, rehab, State1), State1};
 post_init(Message, #state{node_ref=NodeRef}=State) ->
-    lager:info("~p in post_init. Ignoring message: ~p~n", [NodeRef, Message]),
+    lager:warning("~p in post_init. Ignoring message: ~p~n", [NodeRef, Message]),
     State1 = force_abort(State),
     {next_state, state_transition(init, rehab, State1), State1}.
 


### PR DESCRIPTION
This reworks some code to take into account feedback from Kevin and James. 

Sorry about the new PR, I fat-fingered and used : instead of + to force push and nuked the old branch.
