### PR TITLE
Making debug mode consistent across pushy and erchef

### DIFF
--- a/rel/files/opscode-pushy-server
+++ b/rel/files/opscode-pushy-server
@@ -186,7 +186,7 @@ case "$1" in
         echo "====="
         echo ""
         echo ""
-        gdb --quiet --batch -x bin/debug.gdb --args $CMD
+        gdb --quiet --batch -x etc/debug.gdb --args $CMD
         ;;
 
     clear_cache)

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -52,7 +52,7 @@
 {overlay, [
            {mkdir, "log/sasl"},
            {copy, "files/erl", "\{\{erts_vsn\}\}/bin/erl"},
-           {copy, "files/debug.gdb", "bin/debug.gdb"},
+           {copy, "files/debug.gdb", "etc/debug.gdb"},
            {copy, "files/nodetool", "\{\{erts_vsn\}\}/bin/nodetool"},
            {copy, "files/opscode-pushy-server", "bin/opscode-pushy-server"},
            {template, "files/app.config", "etc/app.config"},


### PR DESCRIPTION
I moved the debug.gdb file from bin/ to etc/ based on feedback from Seth F. I agree this is a better home for the file since it isn't executable on its own. This commit moves debug.gdb into etc for the pushy server to make it consistent with erchef.
