### PR TITLE
Abort when non-SMP environment detected

### DIFF
--- a/apps/pushy/src/pushy_app.erl
+++ b/apps/pushy/src/pushy_app.erl
@@ -47,8 +47,9 @@ start(_StartType, _StartArgs) ->
                     Error
             end;
         _ ->
-            lager:critical("Non-SMP environment detected. Aborting."),
-            erlang:halt(336)
+            lager:critical("Push Job server requires at least 2 CPU cores. "
+                           "Server startup aborted because only 1 core was detected."),
+            erlang:halt(1)
     end.
 
 stop(Ctx) ->


### PR DESCRIPTION
The NIF message send API is not thread safe in non-SMP
Erlang VMs. As a result, erlzmq causes the BEAM to dump
core in single-core configurations.

This change detects when the BEAM is running in non-SMP
mode, logs a descriptive error message, and then stops
the VM.
