### PR TITLE
Use db_driver_mod for Sqerl configuration

### DIFF
--- a/rel/db_vars.config
+++ b/rel/db_vars.config
@@ -1,4 +1,4 @@
-{db_type, pgsql}.
+{db_driver_mod, sqerl_pgsql_client}.
 {db_port, 5432}.
 {db_user, "dev"}.
 {db_pass, "opensesame"}.

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -53,8 +53,7 @@
             {error_logger_redirect, true}
         ]},
  {sqerl, [
-          %% The database system you are using (e.g., mysql, pgsql)
-          {db_type, {{db_type}} },
+          {db_driver_mod, {{db_driver_mod}} },
 
           %% Database connection parameters
           {db_host, "{{db_host}}" },
@@ -63,7 +62,7 @@
           {db_pass, "{{db_pass}}" },
           {db_name,   "{{db_name}}" },
           {idle_check, 10000},
-          {prepared_statements, {pushy_sql, statements, [ {{db_type}} ]} },
+          {prepared_statements, {pushy_sql, statements, []} },
           %% what's this?
           {column_transforms, undefined}
          ]},

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -23,7 +23,7 @@
 %% Zeromq Tunings
 {zmq_io_processes, 1}.
 
-%% db_type, db_port, db_user, db_pass, and db_name are all set in
+%% db_driver_mod, db_port, db_user, db_pass, and db_name are all set in
 %% db_vars.config as an overlay
 {db_host, "localhost"}.
 {db_pool_size, 5}.


### PR DESCRIPTION
db_type is outdated; db_driver_mod is the new hotness.

We only use PostgreSQL for Pushy anyway, so we can further simplify a
bit of error handling code in pushy_sql while we're at it.
