### PR TITLE
[oc-pushy-pedant] Wait for nodes to fully stop between tests

### DIFF
--- a/oc-pushy-pedant/spec/pushy/integration/end_to_end_spec.rb
+++ b/oc-pushy-pedant/spec/pushy/integration/end_to_end_spec.rb
@@ -54,7 +54,10 @@ describe "end-to-end-test" do
   after :each do
     if @clients
       @clients.each do |client_name, client|
-        stop_client(client_name) if @clients[client_name][:client]
+        if @clients[client_name][:client]
+          stop_client(client_name)
+          wait_for_node_status('offline', client_name)
+        end
       end
       @clients = nil
     end

--- a/oc-pushy-pedant/spec/pushy/integration/sse_spec.rb
+++ b/oc-pushy-pedant/spec/pushy/integration/sse_spec.rb
@@ -47,7 +47,10 @@ describe "sse-test" do
   after :each do
     if @clients
       @clients.each do |client_name, client|
-        stop_client(client_name) if @clients[client_name][:client]
+        if @clients[client_name][:client]
+          stop_client(client_name)
+          wait_for_node_status('offline', client_name)
+        end
       end
       @clients = nil
     end
@@ -587,7 +590,7 @@ describe "sse-test" do
       # This test isn't very reliable and is hardware dependent
       # The intent was that 4 events have happened by the first read, and the final completion events land in the second
       # However, sometimes the full 6 event stream is read in the first statement, leaving none for the second.
-      # 
+      #
       old_evs = @stream.get_streaming_events
       validate_events(4, old_evs)
       last_id = old_evs[-1].id


### PR DESCRIPTION
Without the wait_for_node_status call, the server may still have the
node listed as online when the next test begins.

Signed-off-by: Steven Danna <steve@chef.io>