### PR TITLE
[oc-pushy-pedant] Don't coerce heartbeat interval to int

### DIFF
--- a/oc-pushy-pedant/spec/pushy/support/end_to_end_util.rb
+++ b/oc-pushy-pedant/spec/pushy/support/end_to_end_util.rb
@@ -28,7 +28,8 @@ shared_context "end_to_end_util" do
 
     let (:client_start_timeout) { 5 }
     let (:job_start_timeout) { 30 }
-    let (:job_status_timeout_default) { 30 * heartbeat_interval }
+    # longest running job is 21 seconds.  Ensure we always are willing to wait at least 21 + 5 seconds
+    let (:job_status_timeout_default) { [30 * heartbeat_interval, 26].max }
     let (:node_availability_timeout) { 10 * 3 } # 3 is the offline_threshold
     let (:node_status_timeout) { (10 * heartbeat_interval) +  5 } # Add some buffer for when heartbeat_interval is set low
     let (:server_restart_timeout) { 45 } # increasing this makes failing tests take longer, but salvages some slow runs

--- a/oc-pushy-pedant/spec/pushy/support/helper_util.rb
+++ b/oc-pushy-pedant/spec/pushy/support/helper_util.rb
@@ -9,7 +9,7 @@ shared_context "helper_util" do
       file = File.read(filename)
       data = JSON.parse(file)
       interval_millis = data['pushy']['opscode-pushy-server']['heartbeat_interval']
-      (interval_millis.to_i)/1000 #return heartbeat interval in seconds
+      (interval_millis.to_i)/1000.0 #return heartbeat interval in seconds (as a float)
     else
       pp "Please run opscode-push-jobs-server-ctl reconfigure before running tests."
     end

--- a/oc-pushy-pedant/spec/pushy/support/sse_util.rb
+++ b/oc-pushy-pedant/spec/pushy/support/sse_util.rb
@@ -111,7 +111,7 @@ shared_context "sse_support" do
       if last_id then
           headers.merge!({'Last-Event-ID' => last_id})
       end
-      
+
       @ep = EventParser.new
       Thread.new {
         conn = @client.get_async(url, :header => headers)
@@ -179,7 +179,7 @@ shared_context "sse_support" do
       if last_id then
           headers.merge!({'Last-Event-ID' => last_id})
       end
-      
+
       @ep = EventParser.new
       Thread.new {
         req = Typhoeus::Request.new(
@@ -284,6 +284,7 @@ shared_context "sse_support" do
   def validate_events(numEvents, evs)
     TestLogger.debug "Validating events. Expected count: #{numEvents}. Actual count: #{evs.length}"
     TestLogger.debug "Event Names: #{evs.map {|e| e.name}}"
+    TestLogger.debug "Full Event Records: #{evs}"
     evs.length.should >= numEvents
     # All ids are unique
     evs.map(&:id).uniq.length.should == evs.length


### PR DESCRIPTION
The heartbeat interval in pushy is in milliseconds.  When coverting it
to seconds we were inadvertantly converting it to an int.  This made
it impossible to, among other things, set up a test config with a
heartbeat_interval < 1000ms.
