### PR TITLE
[SPOOL-403] Add configurable max_body_size

### DIFF
--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -41,6 +41,9 @@ default['pushy']['opscode-pushy-server']['db_pool_size'] = '20'
 default['pushy']['opscode-pushy-server']['ibrowse_max_sessions'] = 256
 default['pushy']['opscode-pushy-server']['ibrowse_max_pipeline_size'] = 1
 
+# Maximum size of requests in bytes
+default['pushy']['opscode-pushy-server']['max_body_size'] = 65536
+
 # Sets the rate of heartbeats between server and client (in milliseconds)
 default['pushy']['opscode-pushy-server']['heartbeat_interval'] = '10000'
 

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -93,6 +93,7 @@
            {metrics_module, folsom_metrics}
           ]},
  {pushy, [
+          {max_body_size, <%= @max_body_size %> },
           {server_name, "<%= @server_name_advertised %>" },
           {heartbeat_interval, <%= @heartbeat_interval %> },
           {zeromq_listen_address, "<%= @zeromq_listen_address %>" },


### PR DESCRIPTION
Doesn't do anything unless we're pulling in chef/pushy_common#24.

![gif-keyboard-6425482654698848306](https://cloud.githubusercontent.com/assets/9912/20070242/3f24537c-a4e5-11e6-8173-6eab7d9bb1d9.gif)
