### PR TITLE
Update runit to 3.0.0+ to unblock the build

### DIFF
--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/Berksfile
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/Berksfile
@@ -3,4 +3,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'enterprise', :git => 'https://github.com/chef-cookbooks/enterprise-chef-common.git'
-cookbook 'runit', '= 1.6.0'
+cookbook 'runit', '>= 3.0.0'


### PR DESCRIPTION
Using the runit 3.0 cookbook gets around the dep solving bug that is causing our build failure.  We're continuing to work on tracking down the bug and opening an issue for it, but I wanted to run this through CI to get things unblocked - and because we're quite out of date for this cookbook anyway...