### PR TITLE
Remove typhoeus from oc-pushy-pedant

### DIFF
--- a/oc-pushy-pedant/Gemfile.lock
+++ b/oc-pushy-pedant/Gemfile.lock
@@ -38,7 +38,6 @@ PATH
   specs:
     oc-pushy-pedant (2.0.0)
       httpclient
-      typhoeus
 
 GEM
   remote: https://rubygems.org/
@@ -86,8 +85,6 @@ GEM
       uuidtools (~> 2.1)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    ethon (0.9.0)
-      ffi (>= 1.3.0)
     ffi (1.9.14)
     ffi-rzmq (2.0.4)
       ffi-rzmq-core (>= 1.0.1)
@@ -98,7 +95,7 @@ GEM
     fuzzyurl (0.8.0)
     hashie (3.4.4)
     highline (1.7.8)
-    httpclient (2.8.0)
+    httpclient (2.8.2.4)
     i18n (0.7.0)
     iniparse (1.4.2)
     ipaddress (0.8.3)
@@ -178,8 +175,6 @@ GEM
       sfl
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    typhoeus (1.0.2)
-      ethon (>= 0.9.0)
     uuidtools (2.1.5)
     wmi-lite (1.0.0)
 
@@ -194,4 +189,4 @@ DEPENDENCIES
   rest-client!
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/oc-pushy-pedant/oc-pushy-pedant.gemspec
+++ b/oc-pushy-pedant/oc-pushy-pedant.gemspec
@@ -11,5 +11,4 @@ Gem::Specification.new do |s|
   s.require_paths = ['spec', 'lib']
 
   s.add_dependency "httpclient"
-  s.add_dependency "typhoeus"
 end

--- a/omnibus/config/projects/opscode-push-jobs-server.rb
+++ b/omnibus/config/projects/opscode-push-jobs-server.rb
@@ -26,7 +26,7 @@ build_version   Omnibus::BuildVersion.new.semver
 build_iteration 1
 
 override :libzmq, version: "4.0.5"
-override :berkshelf, version: "v4.3.5"
+override :'berkshelf-no-depselector', version: "v4.3.5"
 override :chef, version: "v12.13.37"
 override :ohai, version: "v8.19.1"
 override :ruby, version: "2.2.5"


### PR DESCRIPTION
typhoeus depends on libcurl at runtime. We would like to remove curl
from the build. It appears that typhoeus is actually unused in the code
so we can drop this dependency.

Signed-off-by: Steven Danna <steve@chef.io>