### PR TITLE
Use the environment to access passwords

### DIFF
--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -69,8 +69,7 @@
             {error_logger_redirect, true}
         ]},
 
- {chef_secrets, [{provider, chef_secrets_json_file},
-                 {provider_config, [{secrets_file, "/etc/opscode/private-chef-secrets.json"}]}]},
+ {chef_secrets, [{provider, chef_secrets_env}]},
 
  {sqerl, [
           {db_driver_mod, sqerl_pgsql_client},

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/sv-opscode-pushy-server-run.erb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/sv-opscode-pushy-server-run.erb
@@ -2,4 +2,4 @@
 exec 2>&1
 
 export PATH=/opt/opscode-push-jobs-server/embedded/bin:$PATH
-exec chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> env HOME=<%= node['pushy']['opscode-pushy-server']['dir'] %> ERL_EPMD_ADDRESS=127.0.0.1 <%= node['pushy']['install_path'] %>/embedded/service/opscode-pushy-server/bin/opscode-pushy-server foreground
+exec veil-env-helper --pack -s push-jobs-server.pushy_priv_key -s push-jobs-server.pushy_pub_key -s push-jobs-server.sql_password -s chef-server.superuser_key -- chpst -P -u <%= node['private_chef']['user']['username'] %> -U <%= node['private_chef']['user']['username'] %> env HOME=<%= node['pushy']['opscode-pushy-server']['dir'] %> ERL_EPMD_ADDRESS=127.0.0.1 <%= node['pushy']['install_path'] %>/embedded/service/opscode-pushy-server/bin/opscode-pushy-server foreground

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
   0},
  {<<"chef_secrets">>,
   {git,"https://github.com/chef/chef_secrets",
-       {ref,"9e47ba9fc8a31aa2a4f9317de69b677fa34eb17e"}},
+       {ref,"79fceb7a3480d06967c1e5d21103259b7146ba28"}},
   0},
  {<<"ej">>,
   {git,"https://github.com/seth/ej",


### PR DESCRIPTION
This changes the pushy application to use the chef_secrets_env
helper. This will make it easier to change the permissions on
private-chef-secrets.json back to root:root at some point in the
future.

Signed-off-by: Steven Danna <steve@chef.io>