### PR TITLE
Allow opscode_pushy_server vip to be overridden

### DIFF
--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
@@ -59,7 +59,7 @@ module PushJobsServer
       case topology
       when "ha", "tier"
         PushJobsServer['opscode_pushy_server']['ha'] = (topology == 'ha')
-        PushJobsServer['opscode_pushy_server']['vip'] = node['private_chef']['backend_vips']['ipaddress']
+        PushJobsServer['opscode_pushy_server']['vip'] ||= node['private_chef']['backend_vips']['ipaddress']
 
         case node['private_chef']['servers'][node_name]['role']
         when "backend"
@@ -70,7 +70,7 @@ module PushJobsServer
           raise "I don't have a role for you!  Use 'backend' or 'frontend'."
         end
       else
-        PushJobsServer['opscode_pushy_server']['vip'] = node['private_chef']['lb']['api_fqdn']
+        PushJobsServer['opscode_pushy_server']['vip'] ||= node['private_chef']['lb']['api_fqdn']
       end
       generate_hash
     end


### PR DESCRIPTION
Presently, a user cannot leverage push jobs with a highly available chef server
configuration. By allowing a user to set the `opscode_pushy_server['vip']` this
pull request allows users to override the default values assigned by Chef, allowing
push jobs to be leveraged with highly available chef server configurations. As
`opscode_pushy_server['vip']` defaults to `nil`, this should only affect users
that have been instructed to make these changes explicitly.

Signed-off-by: Josh O'Brien <jobrien@chef.io>