### PR TITLE
Use attribute for db_port in pushy configuration

### DIFF
--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -76,7 +76,7 @@
           {config_cb, {chef_secrets_sqerl, config, [{<<"push-jobs-server">>, <<"sql_password">>}]}},
           %% Database connection parameters
           {db_host, "<%= node['pushy']['postgresql']['vip'] %>"},
-          {db_port, 5432},
+          {db_port, <%= node['pushy']['postgresql']['port'] %>},
           {db_user, "<%= node['pushy']['postgresql']['sql_user'] %>"},
           {db_name,   "opscode_pushy" },
           {idle_check, 10000},


### PR DESCRIPTION
This change populates the db_port property in the configuration with the [postgresql port attribute](https://github.com/chef/opscode-pushy-server/blob/master/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb#L79) that is [inherited from the chef-server ](https://github.com/chef/opscode-pushy-server/blob/5b7a7dbaf3a2b4d60ec7c660956c26a59fa9f383/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb#L55) config which allows the push jobs server to work with a non-standard database port.