### PR TITLE
Allow Pushy Server to optionally use a different username for establishing database connections

### DIFF
--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -74,6 +74,7 @@ default['pushy']['opscode-pushy-server']['chef_api_version'] = '11.1.0' # API Ve
 default['pushy']['postgresql']['database_name'] = "opscode_pushy"
 default['pushy']['postgresql']['username'] = "opscode-pgsql"
 default['pushy']['postgresql']['sql_user'] = "opscode_pushy"
+default['pushy']['postgresql']['sql_connection_user'] = nil
 default['pushy']['postgresql']['sql_ro_user'] = "opscode_pushy_ro"
 default['pushy']['postgresql']['vip'] = "127.0.0.1"
 default['pushy']['postgresql']['port'] = 5432

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/ec_postgres.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/ec_postgres.rb
@@ -4,7 +4,7 @@ class EcPostgres
     require 'pg'
     password = opts['db_superuser_password'] || PushServer::Secrets.veil.get('postgresql', 'db_superuser_password')
     postgres = node['pushy']['postgresql'].merge(opts)
-    connection = ::PGconn.open('user' => postgres['db_superuser'],
+    connection = ::PGconn.open('user' => postgres['db_connection_superuser'] || postgres['db_superuser'],
                                'host' => postgres['vip'],
                                'password' => password,
                                'port' => postgres['port'],

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
@@ -51,9 +51,10 @@ module PushJobsServer
 
     def generate_config(node_name)
       # inherit postgres config from chef-server
-      PushJobsServer['postgresql']['vip']           = node['private_chef']['postgresql']['vip']
-      PushJobsServer['postgresql']['port']          = node['private_chef']['postgresql']['port']
-      PushJobsServer['postgresql']['db_superuser']  = node['private_chef']['postgresql']['db_superuser']
+      PushJobsServer['postgresql']['vip']                     = node['private_chef']['postgresql']['vip']
+      PushJobsServer['postgresql']['port']                    = node['private_chef']['postgresql']['port']
+      PushJobsServer['postgresql']['db_superuser']            = node['private_chef']['postgresql']['db_superuser']
+      PushJobsServer['postgresql']['db_connection_superuser'] = node['private_chef']['postgresql']['db_connection_superuser']
 
       topology = node['private_chef']['topology']
       case topology

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/metadata.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Installs/Configures opscode-pushy-server"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.2.0"
 
 depends          'enterprise' # grabbed via Berkshelf + Git

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/providers/pg_user_table_access.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/providers/pg_user_table_access.rb
@@ -1,6 +1,6 @@
 # NOTE:
 #
-# Uses the value of node['private_chef']['postgresql']['db_superuser'] for the superuser name and
+# Uses the value of node['private_chef']['postgresql']['db_connection_superuser'] for the superuser name and
 # access the superuser password via the Secrets module.
 # to make the connection to the postgres server.
 

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/recipes/push_database.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/recipes/push_database.rb
@@ -52,7 +52,7 @@ end
 opscode_pushy_server_pg_sqitch  "#{install_path}/embedded/service/pushy-server-schema" do
   hostname push_attrs['vip']
   port     push_attrs['port']
-  username  push_attrs['db_superuser']
+  username  push_attrs['db_connection_superuser'] || push_attrs['db_superuser']
   password  PushServer::Secrets.veil.get('postgresql', 'db_superuser_password')
   database database_name
 end

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -77,7 +77,7 @@
           %% Database connection parameters
           {db_host, "<%= node['pushy']['postgresql']['vip'] %>"},
           {db_port, <%= node['pushy']['postgresql']['port'] %>},
-          {db_user, "<%= node['pushy']['postgresql']['sql_user'] %>"},
+          {db_user, "<%= node['pushy']['postgresql']['sql_connection_user'] || node['pushy']['postgresql']['sql_user'] %>"},
           {db_name,   "opscode_pushy" },
           {idle_check, 10000},
           {prepared_statements, {pushy_sql, statements, []} },


### PR DESCRIPTION
### Description

This change allows Pushy Server to optionally use a different username for establishing database connections than is used within database queries. This is necessary when using Azure Database for PostgreSQL as an external database.

### Issues Resolved

https://github.com/chef/chef-server/issues/1559

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
