### PR TITLE
Allow Pushy Server to optionally use SSL for establishing database connections

### DIFF
--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/attributes/default.rb
@@ -77,6 +77,7 @@ default['pushy']['postgresql']['sql_user'] = "opscode_pushy"
 default['pushy']['postgresql']['sql_ro_user'] = "opscode_pushy_ro"
 default['pushy']['postgresql']['vip'] = "127.0.0.1"
 default['pushy']['postgresql']['port'] = 5432
+default['pushy']['postgresql']['sslmode'] = 'disable'
 
 ####
 # Chef Pedant

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/ec_postgres.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/ec_postgres.rb
@@ -8,6 +8,7 @@ class EcPostgres
                                'host' => postgres['vip'],
                                'password' => password,
                                'port' => postgres['port'],
+                               'sslmode' => postgres['sslmode'],
                                'dbname' => database)
     begin
       yield connection

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/libraries/pushy_server.rb
@@ -54,6 +54,7 @@ module PushJobsServer
       PushJobsServer['postgresql']['vip']           = node['private_chef']['postgresql']['vip']
       PushJobsServer['postgresql']['port']          = node['private_chef']['postgresql']['port']
       PushJobsServer['postgresql']['db_superuser']  = node['private_chef']['postgresql']['db_superuser']
+      PushJobsServer['postgresql']['sslmode']       = node['private_chef']['postgresql']['sslmode']
 
       topology = node['private_chef']['topology']
       case topology

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/metadata.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Installs/Configures opscode-pushy-server"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.2.0"
 
 depends          'enterprise' # grabbed via Berkshelf + Git

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/providers/pg_sqitch.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/providers/pg_sqitch.rb
@@ -20,7 +20,7 @@ action :deploy do
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
                   "PGPASSWORD" => new_resource.password,
-                  "PGSSLMODE" => node['pushy']['postgresql']['sslmode']
+                  "PGSSLMODE" => new_resource.sslmode
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/providers/pg_sqitch.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/providers/pg_sqitch.rb
@@ -19,7 +19,8 @@ action :deploy do
                deploy #{target} --verify
       EOM
       environment "PERL5LIB" => "", # force us to use omnibus perl
-                  "PGPASSWORD" => new_resource.password
+                  "PGPASSWORD" => new_resource.password,
+                  "PGSSLMODE" => node['pushy']['postgresql']['sslmode']
 
       # Sqitch Return Codes
       # 0 - when changes are applied

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/recipes/push_database.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/recipes/push_database.rb
@@ -55,4 +55,5 @@ opscode_pushy_server_pg_sqitch  "#{install_path}/embedded/service/pushy-server-s
   username  push_attrs['db_superuser']
   password  PushServer::Secrets.veil.get('postgresql', 'db_superuser_password')
   database database_name
+  sslmode  push_attrs['sslmode']
 end

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/resources/pg_sqitch.rb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/resources/pg_sqitch.rb
@@ -8,3 +8,4 @@ attribute :password,       kind_of: String, required: false, default: ""
 attribute :target_version, kind_of: String
 attribute :hostname,       kind_of: String, required: true
 attribute :port,           kind_of: Integer, required: true
+attribute :sslmode,        kind_of: String, required: false, default: "prefer"

--- a/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
+++ b/omnibus/files/pushy-server-cookbooks/opscode-pushy-server/templates/default/opscode-pushy-server.config.erb
@@ -79,6 +79,7 @@
           {db_port, <%= node['pushy']['postgresql']['port'] %>},
           {db_user, "<%= node['pushy']['postgresql']['sql_user'] %>"},
           {db_name,   "opscode_pushy" },
+          {db_options, [{ssl, <%= { 'disable' => false, 'prefer' => true, 'require' => 'required' }[node['pushy']['postgresql']['sslmode']] %>}]},
           {idle_check, 10000},
           {prepared_statements, {pushy_sql, statements, []} },
           {column_transforms, []}


### PR DESCRIPTION
### Description

This change allows Pushy Server to be configured to use SSL to connect to the PostgreSQL database. This is necessary when using Azure Database for PostgreSQL as an external database securely, without disabling `Enforce SSL`.
This change will not actually work until the pinned version of `sqerl` is bumped to at least https://github.com/chef/sqerl/commit/f36fb5c80777769ff9c27adba9340693cfe964f8, and https://github.com/chef/chef_secrets/pull/26 is merged and the dependency is updated here.

### Issues Resolved

https://github.com/chef/chef-server/issues/1559

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>