### PR TITLE
Use new omnibus-toolchain scripts in omnibus-test.sh

### DIFF
--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -14,29 +14,23 @@ create_license_guard_file() {
   sudo touch "/var/opt/$(basename $SERVER_INSTALL_DIR)/.license.accepted"
 }
 
-echo "--- Installing $dep_channel chef-server latest"
-install-omnibus-product -c "$dep_channel" -P chef-server -v latest
-
-echo "--- Installing $channel $product $version"
-package_file="$(install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
-
-if [[ "$package_file" == *.rpm ]]; then
-  check-rpm-signed "$package_file"
-fi
-
-echo "--- Testing $channel $product $version"
-
 export PATH="/opt/opscode-push-jobs-server/bin:/opt/opscode-push-jobs-server/embedded/bin:$PATH"
 export INSTALL_DIR="/opt/opscode-push-jobs-server"
 
-echo ""
-echo ""
-echo "============================================================"
-echo "Verifying ownership of package files"
-echo "============================================================"
-echo ""
+echo "--- Installing $dep_channel chef-server latest"
+/opt/omnibus-toolchain/bin/install-omnibus-product -c "$dep_channel" -P chef-server -v latest
 
-NONROOT_FILES="$(find "$INSTALL_DIR" ! -uid 0 -print)"
+echo "--- Installing $channel $product $version"
+package_file="$(/opt/omnibus-toolchain/bin/install-omnibus-product -c "$channel" -P "$product" -v "$version" -i "$INSTALL_DIR" | tail -n 1)"
+
+echo "--- Verifying omnibus package is signed"
+/opt/omnibus-toolchain/bin/check-omnibus-package-signed "$package_file"
+
+sudo rm -f "$package_file"
+
+echo "--- Verifying ownership of package files"
+
+NONROOT_FILES="$(find "$INSTALL_DIR" ! -user 0 -print)"
 if [[ "$NONROOT_FILES" == "" ]]; then
   echo "Packages files are owned by root.  Continuing verification."
 else
@@ -45,12 +39,7 @@ else
   exit 1
 fi
 
-echo ""
-echo ""
-echo "============================================================"
-echo "Reconfiguring $product"
-echo "============================================================"
-echo ""
+echo "--- Reconfiguring $channel $product $version"
 
 sudo mkdir -p /etc/opscode
 
@@ -82,11 +71,6 @@ create_license_guard_file /opt/opscode-push-jobs-server || true
 sudo opscode-push-jobs-server-ctl reconfigure || true
 sleep 120
 
-echo ""
-echo ""
-echo "============================================================"
-echo "Running verification for $product"
-echo "============================================================"
-echo ""
+echo "--- Running verification for $channel $product $version"
 
 sudo opscode-push-jobs-server-ctl test -J pedant.xml --all


### PR DESCRIPTION
### Description

This just updates the `omnibus-test.sh` script to use tools that have been moved into the omnibus-toolchain. It also makes some changes to output to be more consistent across our omnibus projects.